### PR TITLE
Fix errorformat in help and for watchdogs

### DIFF
--- a/doc/vimhelplint.txt
+++ b/doc/vimhelplint.txt
@@ -87,7 +87,7 @@ COMMANDS				*vimhelplint-commands*
 	Runs syntax check and echo results. The messages are formatted as
 	resolved by the following 'errorformat' patterns.
 >
-	set efm=%f:%l:%c:%trror:%n: %m,%f:%l:%c:%tarning:%n: %m
+	set efm=%f:%l:%c:%trror:%n:%m,%f:%l:%c:%tarning:%n:%m
 <
 ==============================================================================
 FUNCTIONS				*vimhelplint-functions*

--- a/ftplugin/help_lint.vim
+++ b/ftplugin/help_lint.vim
@@ -637,7 +637,7 @@ if exists(':WatchdogsRun') == 2
         \   'watchdogs_checker/vimhelplint' : {
         \     'command': 'vim',
         \     'exec' : '%C -X -N -u NONE -i NONE -V1 -e -s -c "set rtp+=' . s:get_plugin_dir() . '" -c "silent filetype plugin on" -c "silent edit %s" -c "VimhelpLintEcho" -c "qall!"',
-        \     'errorformat': '%f:%l:%c:%trror:%n: %m,%f:%l:%c:%tarning:%n: %m',
+        \     'errorformat': '%f:%l:%c:%trror:%n:%m,%f:%l:%c:%tarning:%n:%m',
         \    },
         \ }
   call s:integrate_watchdog_config()


### PR DESCRIPTION
The space used there is not actually echoed.

btw: https://github.com/neomake/neomake/pull/1107 adds vimhelplint to Neomake (via a wrapper script).