### PR TITLE
doc: fix some wording and link to Neomake

### DIFF
--- a/doc/vimhelplint.txt
+++ b/doc/vimhelplint.txt
@@ -107,8 +107,9 @@ registered in |quickfix|. This plugin makes easier to find erroneous lines. If
 vim-hier is available, |vimhelplint| use it automatically without any setting.
 
 
-The following plugins run syntax check automatically. Note that |:VimhelpLint|
-command is sometimes heavy, use that kind of plugins carefully.
+The following plugins can run syntax check automatically. Note that running
+vimhelplint is slow in general, so you better use one with async support, and
+you should be careful about enabling it by default / invoking it too often.
 
 vim-watchdogs~
 |watchdogs.vim| (https://github.com/osyo-manga/vim-watchdogs) is a plugin for
@@ -121,7 +122,7 @@ asynchronous syntax checking. Install the |watchdogs.vim| and the requirements
 <
 
 syntastic~
-|syntastic| (https://github.com/scrooloose/syntastic) is a plugin to do syntax
+|Syntastic| (https://github.com/scrooloose/syntastic) is a plugin to do syntax
 check automatically. Install it and write a line to vimrc.
 >
 	let g:syntastic_help_checkers = ['vimhelplint']
@@ -129,13 +130,12 @@ check automatically. Install it and write a line to vimrc.
 
 Neomake~
 Neomake (https://github.com/neomake/neomake) is a framework for Neovim/Vim to
-run lint tools asynchronously. Install it and run:
+run lint tools asynchronously. Install it and run the following in the root
+directory of the plugin to install vimhelplint:
 >
 	make build/vimhelplint
 <
-in the root directory of Neomake plugin, it downloads vimhelplint
-automatically. Then you can run vimhelplint asynchronously and more!
-Check |Neomake.txt|.
+Then you can run vimhelplint asynchronously and more (see |Neomake|):
 >
 	:Neomake vimhelplint
 <


### PR DESCRIPTION
Added the *Neomake* doc anchor in https://github.com/neomake/neomake/pull/1237.