### PR TITLE
Skip language annotation pattern

### DIFF
--- a/ftplugin/help_lint.vim
+++ b/ftplugin/help_lint.vim
@@ -147,7 +147,7 @@ function! s:extract_hypertexts(bufnr) abort  "{{{
     if !skip
       let scraped += s:extract_hypertexts_from_a_line(lnum, line)
 
-      if line =~# '\%(^\| \)>$'
+      if line =~# '\%(^\| \)>[a-z0-9]*$'
         let skip = 1
       endif
     endif


### PR DESCRIPTION
I have added the language annotation pattern.

https://github.com/vim/vim/commit/6fea0a54804fc36ab7138a66210b0eb380d96198